### PR TITLE
Add sequence mode for sequential track playback (re-open)

### DIFF
--- a/app/src/main/java/dev/cognitivity/chronal/ChronalApp.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ChronalApp.kt
@@ -55,6 +55,7 @@ class ChronalApp : Application() {
                 bpm = Settings.getBpm(),
                 tracks = tracks.toMutableList()
             )
+            metronome.setSequence(tracksSetting.sequence)
 
             PracticeReminderScheduler.initialize(applicationContext)
         }

--- a/app/src/main/java/dev/cognitivity/chronal/activity/PresetActivity.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/activity/PresetActivity.kt
@@ -388,6 +388,7 @@ class PresetActivity : BaseActivity() {
                             val metronome = ChronalApp.getInstance().metronome
                             metronome.bpm = preset.config.bpm
                             metronome.tracks = preset.config.tracks.map { MetronomeTrack.fromSetting(it) }.toMutableList()
+                            metronome.setSequence(preset.config.sequence)
 
                             lifecycleScope.launch {
                                 Settings.METRONOME_CONFIG.save(preset.config)

--- a/app/src/main/java/dev/cognitivity/chronal/metronome/Metronome.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/metronome/Metronome.kt
@@ -47,6 +47,7 @@ import dev.cognitivity.chronal.metronome.modifiers.TempoChangeDuration
 import dev.cognitivity.chronal.rhythm.metronome.Beat
 import dev.cognitivity.chronal.round
 import dev.cognitivity.chronal.settings.Settings
+import dev.cognitivity.chronal.settings.types.json.MetronomeSequence
 import dev.cognitivity.chronal.settings.types.json.SimpleRhythm
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -124,6 +125,22 @@ class Metronome(
     private val _countInActive = MutableStateFlow(false)
     val countInActive: StateFlow<Boolean> = _countInActive
 
+    val sequencer = MetronomeSequencer()
+
+    fun setSequence(sequence: MetronomeSequence) {
+        val wasPlaying: Boolean
+        synchronized(schedulerLock) {
+            wasPlaying = playing
+            sequencer.setSequence(sequence)
+        }
+        if (wasPlaying) {
+            stop()
+            start()
+        }
+    }
+
+    private fun sequenceActive() = sequencer.isActive(tracks.size)
+
     init {
         handlerThread.start()
         handler = Handler(handlerThread.looper)
@@ -162,6 +179,11 @@ class Metronome(
                     track.sampleRemainder = 0.0
                 }
 
+                sequencer.reset()
+                if (sequenceActive()) {
+                    sequencer.advanceToNextValidStep(tracks.size)
+                }
+
                 ongoingSounds.clear()
             }
 
@@ -177,6 +199,7 @@ class Metronome(
         playing = false
         handler.removeCallbacks(audioRunnable)
         ongoingSounds.clear()
+        sequencer.reset()
         tracks.forEach { it.onPause(true) }
         modifiers.forEach { it.onStop() }
         audioTrack.pause()
@@ -257,6 +280,12 @@ class Metronome(
 
     private fun mixTracks(outputBuffer: FloatArray, frameStartSample: Long, frameEndSample: Long) {
         mixCountIn(outputBuffer, frameStartSample, frameEndSample)
+        if (sequenceActive()) {
+            // wait for the count-in to finish; its completion resets all track positions
+            if (!_countInActive.value) mixSequence(outputBuffer, frameStartSample, frameEndSample)
+            return
+        }
+
         for((trackIndex, track) in tracks.withIndex()) {
             if (!track.enabled) continue
 
@@ -324,6 +353,55 @@ class Metronome(
                 }
                 return
             }
+        }
+    }
+
+    private fun mixSequence(outputBuffer: FloatArray, frameStartSample: Long, frameEndSample: Long) {
+        var step = sequencer.currentStep() ?: return
+        var trackIndex = step.trackIndex
+        var track = tracks.getOrNull(trackIndex) ?: return
+        var pattern = track.getIntervals()
+        if (pattern.isEmpty()) return
+
+        while (track.nextBeatSample < frameEndSample) {
+            if (track.nextBeatSample < frameStartSample - sampleRate) {
+                track.nextBeatSample = frameStartSample
+            }
+
+            var beatIndex = (track.index + 1).mod(pattern.size)
+            var beat = pattern[beatIndex]
+
+            // the next beat starts a new bar; switch to the next step once this one has played its bars
+            if (beat.index == 0) {
+                if (sequencer.barsStarted >= step.bars) {
+                    val switchSample = track.nextBeatSample
+                    val remainder = track.sampleRemainder
+                    step = sequencer.advanceToNextValidStep(tracks.size)
+                    trackIndex = step.trackIndex
+                    track = tracks[trackIndex]
+                    pattern = track.getIntervals()
+                    if (pattern.isEmpty()) return
+
+                    track.index = -1
+                    track.nextBeatSample = switchSample
+                    track.sampleRemainder = remainder
+                    beatIndex = 0
+                    beat = pattern[0]
+                }
+                sequencer.onBarStart(trackIndex)
+            }
+
+            track.index = beatIndex
+
+            if (beat.duration >= 0) {
+                mixTick(outputBuffer, frameStartSample, track.nextBeatSample, trackIndex, beat.isHigh)
+            }
+            track.onUpdate(beat)
+            modifiers.forEach { it.onTick(track, beat) }
+
+            nextBeat(track, beat)
+
+            if (track.nextBeatSample - frameStartSample > frameSize * 1024L) break
         }
     }
 

--- a/app/src/main/java/dev/cognitivity/chronal/metronome/MetronomeSequencer.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/metronome/MetronomeSequencer.kt
@@ -1,0 +1,87 @@
+/*
+ * Chronal: Metronome app for Android
+ * Copyright (C) 2026  cognitivity
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cognitivity.chronal.metronome
+
+import dev.cognitivity.chronal.settings.types.json.MetronomeSequence
+import dev.cognitivity.chronal.settings.types.json.SequenceStep
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+data class SequencePosition(
+    val stepIndex: Int,
+    val trackIndex: Int,
+    val bar: Int,
+    val totalBars: Int,
+)
+
+class MetronomeSequencer {
+    var sequence: MetronomeSequence = MetronomeSequence()
+        private set
+
+    var stepIndex: Int = -1
+    var barsStarted: Int = 0
+
+    private val _positionEvents = MutableSharedFlow<SequencePosition?>(replay = 1)
+    val positionEvents: SharedFlow<SequencePosition?> = _positionEvents.asSharedFlow()
+
+    fun setSequence(newSequence: MetronomeSequence) {
+        sequence = newSequence
+        reset()
+    }
+
+    fun isActive(trackCount: Int): Boolean {
+        return sequence.enabled && sequence.validSteps(trackCount).isNotEmpty()
+    }
+
+    fun reset() {
+        stepIndex = -1
+        barsStarted = 0
+        _positionEvents.tryEmit(null)
+    }
+
+    fun currentStep(): SequenceStep? = sequence.steps.getOrNull(stepIndex)
+
+    fun advanceToNextValidStep(trackCount: Int): SequenceStep {
+        val steps = sequence.steps
+        for (offset in 1..steps.size) {
+            val index = (stepIndex + offset).mod(steps.size)
+            val step = steps[index]
+            if (step.trackIndex in 0 until trackCount && step.bars > 0) {
+                stepIndex = index
+                barsStarted = 0
+                return step
+            }
+        }
+        throw IllegalStateException("No valid sequence step found")
+    }
+
+    fun onBarStart(trackIndex: Int) {
+        barsStarted++
+        val step = currentStep() ?: return
+        _positionEvents.tryEmit(
+            SequencePosition(
+                stepIndex = stepIndex,
+                trackIndex = trackIndex,
+                bar = barsStarted,
+                totalBars = step.bars,
+            )
+        )
+    }
+}

--- a/app/src/main/java/dev/cognitivity/chronal/settings/Settings.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/settings/Settings.kt
@@ -34,6 +34,7 @@ import dev.cognitivity.chronal.settings.types.json.Instruments
 import dev.cognitivity.chronal.settings.types.json.MetronomeConfig
 import dev.cognitivity.chronal.settings.types.json.MetronomeConfigTrack
 import dev.cognitivity.chronal.settings.types.json.MetronomePreset
+import dev.cognitivity.chronal.settings.types.json.MetronomeSequence
 import dev.cognitivity.chronal.settings.types.json.TempoMarking
 
 object Settings {
@@ -186,12 +187,29 @@ object Settings {
         // ensure at least 1 active track
         if(tracks.count { it != metronomeConfigTrack && it.enabled } == 0) return false
 
-        if(!tracks.contains(metronomeConfigTrack)) return false
+        val removedIndex = tracks.indexOf(metronomeConfigTrack)
+        if(removedIndex == -1) return false
 
-        tracks.remove(metronomeConfigTrack)
-        METRONOME_CONFIG.set(config.copy(tracks = tracks))
+        tracks.removeAt(removedIndex)
 
-        ChronalApp.getInstance().metronome.tracks = config.tracks.map { MetronomeTrack.fromSetting(it) }.toMutableList()
+        val steps = config.sequence.steps
+            .filter { it.trackIndex != removedIndex }
+            .map { if(it.trackIndex > removedIndex) it.copy(trackIndex = it.trackIndex - 1) else it }
+        val sequence = config.sequence.copy(
+            enabled = config.sequence.enabled && steps.isNotEmpty(),
+            steps = steps
+        )
+        METRONOME_CONFIG.set(config.copy(tracks = tracks, sequence = sequence))
+
+        val metronome = ChronalApp.getInstance().metronome
+        metronome.tracks = tracks.map { MetronomeTrack.fromSetting(it) }.toMutableList()
+        metronome.setSequence(sequence)
         return true
+    }
+
+    fun setSequence(sequence: MetronomeSequence) {
+        val config = METRONOME_CONFIG.get()
+        METRONOME_CONFIG.set(config.copy(sequence = sequence))
+        ChronalApp.getInstance().metronome.setSequence(sequence)
     }
 }

--- a/app/src/main/java/dev/cognitivity/chronal/settings/types/json/MetronomeConfig.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/settings/types/json/MetronomeConfig.kt
@@ -162,7 +162,8 @@ data class TrackColorPalette(val color: Color, val onColor: Color, val colorCont
 data class MetronomeConfig(
     val version: Int = Settings.getCurrentVersionCode(),
     val bpm: Float,
-    val tracks: List<MetronomeConfigTrack>
+    val tracks: List<MetronomeConfigTrack>,
+    val sequence: MetronomeSequence = MetronomeSequence()
 ) {
     companion object {
         fun default(): MetronomeConfig {
@@ -206,7 +207,14 @@ data class MetronomeConfig(
             return MetronomeConfig(
                 version = jsonObject.get("version")?.asInt ?: 0,
                 bpm = jsonObject.get("bpm")?.asFloat ?: 0f,
-                tracks = tracks.ifEmpty { default().tracks }
+                tracks = tracks.ifEmpty { default().tracks },
+                sequence = jsonObject.get("sequence")?.let {
+                    try {
+                        MetronomeSequence.fromJson(it.asJsonObject)
+                    } catch (_: Exception) {
+                        null
+                    }
+                } ?: MetronomeSequence()
             )
         }
     }
@@ -218,6 +226,7 @@ data class MetronomeConfig(
             add("tracks", JsonArray().apply {
                 tracks.forEach { add(it.toJson()) }
             })
+            add("sequence", sequence.toJson())
         }
     }
 }

--- a/app/src/main/java/dev/cognitivity/chronal/settings/types/json/MetronomeSequence.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/settings/types/json/MetronomeSequence.kt
@@ -1,0 +1,81 @@
+/*
+ * Chronal: Metronome app for Android
+ * Copyright (C) 2026  cognitivity
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cognitivity.chronal.settings.types.json
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+
+data class SequenceStep(
+    val trackIndex: Int,
+    val bars: Int,
+) {
+    companion object {
+        fun fromJson(jsonObject: JsonObject): SequenceStep {
+            return SequenceStep(
+                trackIndex = jsonObject.get("trackIndex")?.asInt ?: 0,
+                bars = (jsonObject.get("bars")?.asInt ?: 1).coerceAtLeast(1),
+            )
+        }
+    }
+
+    fun toJson(): JsonObject {
+        return JsonObject().apply {
+            addProperty("trackIndex", trackIndex)
+            addProperty("bars", bars)
+        }
+    }
+}
+
+data class MetronomeSequence(
+    val enabled: Boolean = false,
+    val steps: List<SequenceStep> = emptyList(),
+) {
+    companion object {
+        fun fromJson(jsonObject: JsonObject): MetronomeSequence {
+            val steps = jsonObject.get("steps")
+                ?.asJsonArray
+                ?.mapNotNull {
+                    try {
+                        SequenceStep.fromJson(it.asJsonObject)
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+                ?: emptyList()
+
+            return MetronomeSequence(
+                enabled = jsonObject.get("enabled")?.asBoolean ?: false,
+                steps = steps,
+            )
+        }
+    }
+
+    fun toJson(): JsonObject {
+        return JsonObject().apply {
+            addProperty("enabled", enabled)
+            add("steps", JsonArray().apply {
+                steps.forEach { add(it.toJson()) }
+            })
+        }
+    }
+
+    fun validSteps(trackCount: Int): List<IndexedValue<SequenceStep>> {
+        return steps.withIndex().filter { it.value.trackIndex in 0 until trackCount && it.value.bars > 0 }
+    }
+}

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/MetronomeUI.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/MetronomeUI.kt
@@ -43,6 +43,8 @@ import dev.cognitivity.chronal.R
 import dev.cognitivity.chronal.activity.MainActivity
 import dev.cognitivity.chronal.ui.metronome.components.MetronomeDisplay
 import dev.cognitivity.chronal.ui.metronome.components.PlayButton
+import dev.cognitivity.chronal.ui.metronome.components.SequenceProgressLabel
+import dev.cognitivity.chronal.ui.metronome.components.SequenceSheet
 import dev.cognitivity.chronal.ui.metronome.components.TempoControlsDialog
 import dev.cognitivity.chronal.ui.metronome.components.TrackList
 import dev.cognitivity.chronal.ui.metronome.components.metronomeGestures
@@ -171,6 +173,10 @@ fun MetronomePageMain(mainActivity: MainActivity, viewModel: MetronomeViewModel,
                         DisplayMode.GRID -> GridDisplay(viewModel, tracks)
                         DisplayMode.PIE -> PieDisplay(viewModel, tracks)
                     }
+                    SequenceProgressLabel(
+                        viewModel = viewModel,
+                        modifier = Modifier.align(Alignment.TopCenter).padding(top = 24.dp)
+                    )
                     IconButton(
                         onClick = { viewModel.setFullscreenMode(false) },
                         modifier = Modifier.align(Alignment.TopEnd).padding(16.dp)
@@ -190,6 +196,15 @@ fun MetronomePageMain(mainActivity: MainActivity, viewModel: MetronomeViewModel,
             metronome, viewModel,
             onDismissRequest = {
                 viewModel.setShowBpmDialog(false)
+            }
+        )
+    }
+
+    if(viewModel.showSequenceSheet.collectAsState().value) {
+        SequenceSheet(
+            viewModel = viewModel,
+            onDismissRequest = {
+                viewModel.setShowSequenceSheet(false)
             }
         )
     }

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/MetronomeViewModel.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/MetronomeViewModel.kt
@@ -24,14 +24,22 @@ import android.os.CombinedVibration
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dev.cognitivity.chronal.ChronalApp
 import dev.cognitivity.chronal.R
 import dev.cognitivity.chronal.activity.vibratorManager
 import dev.cognitivity.chronal.metronome.MetronomeTrack
+import dev.cognitivity.chronal.metronome.SequencePosition
 import dev.cognitivity.chronal.settings.Settings
+import dev.cognitivity.chronal.settings.types.json.MetronomeSequence
+import dev.cognitivity.chronal.settings.types.json.SequenceStep
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -80,12 +88,38 @@ class MetronomeViewModel: ViewModel() {
     private val _lastTapTime = MutableStateFlow(0L)
     val lastTapTime: StateFlow<Long> = _lastTapTime.asStateFlow()
 
+    private val _sequence = MutableStateFlow(Settings.METRONOME_CONFIG.get().sequence)
+    val sequence: StateFlow<MetronomeSequence> = _sequence.asStateFlow()
+
+    private val _showSequenceSheet = MutableStateFlow(false)
+    val showSequenceSheet: StateFlow<Boolean> = _showSequenceSheet.asStateFlow()
+
+    private val _sequencePosition = MutableStateFlow<SequencePosition?>(null)
+    val sequencePosition: StateFlow<SequencePosition?> = _sequencePosition.asStateFlow()
+
     init {
         syncMetronomeState()
+
+        viewModelScope.launch {
+            metronome.sequencer.positionEvents.collect { position ->
+                if (position == null) {
+                    _sequencePosition.value = null
+                    return@collect
+                }
+                val timestamp = metronome.timestamp
+                launch {
+                    delay(Settings.VISUAL_LATENCY.get().toLong())
+                    if (metronome.playing && timestamp == metronome.timestamp) {
+                        _sequencePosition.value = position
+                    }
+                }
+            }
+        }
     }
 
     fun syncMetronomeState() {
         _tracks.value = metronome.tracks.toList()
+        _sequence.value = Settings.METRONOME_CONFIG.get().sequence
 
         CoroutineScope(Dispatchers.Main).launch {
             metronome.tracks[0].pauseEvents.collect { paused ->
@@ -100,6 +134,8 @@ class MetronomeViewModel: ViewModel() {
         metronome.bpm = config.bpm
         _tracks.value = tracks.toMutableList()
         metronome.tracks = tracks.toMutableList()
+        metronome.setSequence(config.sequence)
+        _sequence.value = config.sequence
         setPlaying(ChronalApp.getInstance().metronome.playing)
     }
 
@@ -163,6 +199,20 @@ class MetronomeViewModel: ViewModel() {
         }
     }
 
+    fun setSequence(newValue: MetronomeSequence) {
+        _sequence.value = newValue
+        Settings.setSequence(newValue)
+        CoroutineScope(Dispatchers.Main).launch {
+            Settings.METRONOME_CONFIG.save()
+        }
+    }
+    fun setSequenceEnabled(enabled: Boolean) = setSequence(sequence.value.copy(enabled = enabled))
+    fun setSequenceSteps(steps: List<SequenceStep>) {
+        val current = sequence.value
+        setSequence(current.copy(enabled = current.enabled && steps.isNotEmpty(), steps = steps))
+    }
+    fun setShowSequenceSheet(newValue: Boolean) { _showSequenceSheet.value = newValue }
+
     fun setSettingsExpanded(newValue: Boolean) { _settingsExpanded.value = newValue }
     fun setModesExpanded(newValue: Boolean) { _modesExpanded.value = newValue }
     fun setDisplayMode(newValue: DisplayMode) { _displayMode.value = newValue }
@@ -173,4 +223,20 @@ class MetronomeViewModel: ViewModel() {
     fun setIntervals(newValue: List<Long>) { _intervals.value = newValue }
     fun addInterval(newValue: Long) { _intervals.value += newValue }
     fun setLastTapTime(newValue: Long) { _lastTapTime.value = newValue }
+}
+
+/**
+ * The track the visualizer should show while sequence mode is enabled:
+ * the active step's track while playing, otherwise the first valid step's track.
+ * Null when sequence mode is disabled or has no valid steps.
+ */
+@Composable
+fun MetronomeViewModel.sequenceDisplayTrack(tracks: List<MetronomeTrack>): MetronomeTrack? {
+    val sequence by sequence.collectAsState()
+    val position by sequencePosition.collectAsState()
+    if (!sequence.enabled) return null
+    val index = position?.trackIndex
+        ?: sequence.validSteps(tracks.size).firstOrNull()?.value?.trackIndex
+        ?: return null
+    return tracks.getOrNull(index)
 }

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/components/MetronomeDisplay.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/components/MetronomeDisplay.kt
@@ -85,6 +85,17 @@ fun MetronomeDisplay(
                     }
                 }
             }
+            Row(
+                modifier = Modifier.align(Alignment.TopEnd)
+            ) {
+                SequenceButton(viewModel)
+            }
+
+            SequenceProgressLabel(
+                viewModel = viewModel,
+                modifier = Modifier.align(Alignment.TopCenter).padding(top = 12.dp)
+            )
+
             IconButton(
                 onClick = { viewModel.setFullscreenMode(true) },
                 modifier = Modifier.align(Alignment.BottomEnd)
@@ -96,6 +107,44 @@ fun MetronomeDisplay(
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun SequenceButton(viewModel: MetronomeViewModel) {
+    val sequence by viewModel.sequence.collectAsState()
+
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+        tooltip = { PlainTooltip { Text(stringResource(R.string.metronome_sequence_open)) } },
+        state = rememberTooltipState(),
+    ) {
+        IconButton(
+            onClick = { viewModel.setShowSequenceSheet(true) }
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.outline_playlist_play_24),
+                contentDescription = stringResource(R.string.metronome_sequence_open),
+                tint = if (sequence.enabled) MaterialTheme.colorScheme.primary else LocalContentColor.current
+            )
+        }
+    }
+}
+
+@Composable
+fun SequenceProgressLabel(viewModel: MetronomeViewModel, modifier: Modifier = Modifier) {
+    val position by viewModel.sequencePosition.collectAsState()
+    val tracks by viewModel.tracks.collectAsState()
+
+    val currentPosition = position ?: return
+    val name = tracks.getOrNull(currentPosition.trackIndex)?.name ?: return
+
+    Text(
+        text = stringResource(R.string.metronome_sequence_progress, name, currentPosition.bar, currentPosition.totalBars),
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier
+    )
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/components/SequenceSheet.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/components/SequenceSheet.kt
@@ -1,0 +1,337 @@
+/*
+ * Chronal: Metronome app for Android
+ * Copyright (C) 2026  cognitivity
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cognitivity.chronal.ui.metronome.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import dev.cognitivity.chronal.R
+import dev.cognitivity.chronal.settings.types.json.SequenceStep
+import dev.cognitivity.chronal.ui.metronome.MetronomeViewModel
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
+
+private const val MAX_BARS = 99
+
+private data class SequenceStepEntry(val id: Long, val step: SequenceStep)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun SequenceSheet(viewModel: MetronomeViewModel, onDismissRequest: () -> Unit) {
+    val sequence by viewModel.sequence.collectAsState()
+    val tracks by viewModel.tracks.collectAsState()
+    val position by viewModel.sequencePosition.collectAsState()
+
+    var nextId by remember { mutableLongStateOf(0L) }
+    val stepEntries = remember {
+        mutableStateListOf<SequenceStepEntry>().apply {
+            viewModel.sequence.value.steps.forEach { step ->
+                add(SequenceStepEntry(nextId++, step))
+            }
+        }
+    }
+
+    fun commitSteps() {
+        viewModel.setSequenceSteps(stepEntries.map { it.step })
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.outline_playlist_play_24),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = stringResource(R.string.metronome_sequence),
+                    style = MaterialTheme.typography.headlineMediumEmphasized,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f)
+                        .padding(horizontal = 8.dp)
+                )
+                Switch(
+                    checked = sequence.enabled,
+                    enabled = stepEntries.isNotEmpty(),
+                    onCheckedChange = { viewModel.setSequenceEnabled(it) }
+                )
+            }
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 12.dp))
+
+            if (stepEntries.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.metronome_sequence_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 24.dp)
+                )
+            } else {
+                val lazyListState = rememberLazyListState()
+                val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
+                    stepEntries.add(to.index, stepEntries.removeAt(from.index))
+                    commitSteps()
+                }
+
+                LazyColumn(
+                    state = lazyListState,
+                    modifier = Modifier.fillMaxWidth()
+                        .weight(1f, fill = false)
+                        .padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(3.dp),
+                    contentPadding = PaddingValues(vertical = 8.dp)
+                ) {
+                    itemsIndexed(stepEntries, key = { _, entry -> entry.id }) { index, entry ->
+                        ReorderableItem(reorderableState, key = entry.id) {
+                            val isActive = sequence.enabled && position?.stepIndex == index
+                            SequenceStepRow(
+                                viewModel = viewModel,
+                                entry = entry,
+                                topRounded = index == 0,
+                                bottomRounded = index == stepEntries.size - 1,
+                                isActive = isActive,
+                                activeBar = if (isActive) position?.bar else null,
+                                dragHandle = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.outline_drag_handle_24),
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.outline,
+                                        modifier = Modifier.padding(start = 12.dp)
+                                            .draggableHandle()
+                                    )
+                                },
+                                onStepChanged = { newStep ->
+                                    stepEntries[index] = entry.copy(step = newStep)
+                                    commitSteps()
+                                },
+                                onDelete = {
+                                    stepEntries.removeAt(index)
+                                    commitSteps()
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+
+            FilledTonalButton(
+                onClick = {
+                    val trackIndex = stepEntries.lastOrNull()?.step?.trackIndex?.coerceIn(0, tracks.size - 1) ?: 0
+                    stepEntries.add(SequenceStepEntry(nextId++, SequenceStep(trackIndex = trackIndex, bars = 1)))
+                    commitSteps()
+                },
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+                    .padding(vertical = 12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = null
+                )
+                Text(
+                    text = stringResource(R.string.metronome_sequence_add_step),
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun SequenceStepRow(
+    viewModel: MetronomeViewModel,
+    entry: SequenceStepEntry,
+    topRounded: Boolean,
+    bottomRounded: Boolean,
+    isActive: Boolean,
+    activeBar: Int?,
+    dragHandle: @Composable () -> Unit,
+    onStepChanged: (SequenceStep) -> Unit,
+    onDelete: () -> Unit,
+) {
+    val tracks by viewModel.tracks.collectAsState()
+    val step = entry.step
+    val track = tracks.getOrNull(step.trackIndex)
+    var trackPickerExpanded by remember { mutableStateOf(false) }
+
+    val shape = RoundedCornerShape(
+        topStart = if (topRounded) 12.dp else 6.dp,
+        topEnd = if (topRounded) 12.dp else 6.dp,
+        bottomStart = if (bottomRounded) 12.dp else 6.dp,
+        bottomEnd = if (bottomRounded) 12.dp else 6.dp
+    )
+
+    Row(
+        modifier = Modifier.fillMaxWidth()
+            .clip(shape)
+            .background(
+                if (isActive) MaterialTheme.colorScheme.primaryContainer
+                else MaterialTheme.colorScheme.surfaceContainerHigh
+            )
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        dragHandle()
+
+        Box(
+            modifier = Modifier.weight(1f)
+                .padding(horizontal = 12.dp)
+        ) {
+            Row(
+                modifier = Modifier.clip(RoundedCornerShape(8.dp))
+                    .clickable { trackPickerExpanded = true }
+                    .padding(horizontal = 4.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (track != null) {
+                    Box(
+                        modifier = Modifier.size(12.dp)
+                            .clip(CircleShape)
+                            .background(track.color.getPalette().color)
+                    )
+                }
+                Text(
+                    text = track?.name ?: "—",
+                    style = MaterialTheme.typography.titleMediumEmphasized,
+                    color = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer
+                        else MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+            DropdownMenu(
+                expanded = trackPickerExpanded,
+                onDismissRequest = { trackPickerExpanded = false }
+            ) {
+                for ((index, option) in tracks.withIndex()) {
+                    DropdownMenuItem(
+                        text = { Text(option.name) },
+                        leadingIcon = {
+                            Box(
+                                modifier = Modifier.size(12.dp)
+                                    .clip(CircleShape)
+                                    .background(option.color.getPalette().color)
+                            )
+                        },
+                        onClick = {
+                            trackPickerExpanded = false
+                            onStepChanged(step.copy(trackIndex = index))
+                        }
+                    )
+                }
+            }
+        }
+
+        if (isActive && activeBar != null) {
+            Text(
+                text = "$activeBar/${step.bars}",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+        }
+
+        IconButton(
+            onClick = { onStepChanged(step.copy(bars = (step.bars - 1).coerceAtLeast(1))) },
+            enabled = step.bars > 1
+        ) {
+            Text(
+                text = "−",
+                style = MaterialTheme.typography.titleMediumEmphasized
+            )
+        }
+        Text(
+            text = pluralStringResource(R.plurals.metronome_sequence_bars, step.bars, step.bars),
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (isActive) MaterialTheme.colorScheme.onPrimaryContainer
+                else MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+        IconButton(
+            onClick = { onStepChanged(step.copy(bars = (step.bars + 1).coerceAtMost(MAX_BARS))) },
+            enabled = step.bars < MAX_BARS
+        ) {
+            Text(
+                text = "+",
+                style = MaterialTheme.typography.titleMediumEmphasized
+            )
+        }
+
+        IconButton(
+            onClick = onDelete
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(R.string.metronome_sequence_remove_step),
+                tint = MaterialTheme.colorScheme.outline
+            )
+        }
+    }
+}

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/components/TrackItem.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/components/TrackItem.kt
@@ -54,6 +54,7 @@ fun TrackItem(
     track: MetronomeTrack,
     topRounded: Boolean,
     bottomRounded: Boolean,
+    switchEnabled: Boolean = true,
     onCheckedChanged: (Boolean) -> Unit = {},
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = {}
@@ -109,6 +110,7 @@ fun TrackItem(
         val palette = track.color.getPalette()
         Switch(
             checked = enabled,
+            enabled = switchEnabled,
             onCheckedChange = {
                 onCheckedChanged(it)
             },

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/components/TrackList.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/components/TrackList.kt
@@ -66,6 +66,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun TrackList(viewModel: MetronomeViewModel, modifier: Modifier = Modifier) {
     val tracks by viewModel.tracks.collectAsState()
+    val sequence by viewModel.sequence.collectAsState()
     var settingsDialogIndex by remember { mutableStateOf<Int?>(null) }
 
     fun openEditor(index: Int, track: MetronomeTrack) {
@@ -161,6 +162,7 @@ fun TrackList(viewModel: MetronomeViewModel, modifier: Modifier = Modifier) {
                 contentAlignment = Alignment.Center
             ) {
                 TrackItem(track, topRounded, bottomRounded,
+                    switchEnabled = !sequence.enabled,
                     onCheckedChanged = { enabled ->
                         viewModel.setTrackEnabled(index, enabled)
                     },

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/pages/CircularDisplay.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/pages/CircularDisplay.kt
@@ -31,12 +31,14 @@ import dev.cognitivity.chronal.ChronalApp
 import dev.cognitivity.chronal.metronome.MetronomeTrack
 import dev.cognitivity.chronal.toPx
 import dev.cognitivity.chronal.ui.metronome.MetronomeViewModel
+import dev.cognitivity.chronal.ui.metronome.sequenceDisplayTrack
 import dev.cognitivity.chronal.ui.metronome.components.CircularClock
 import dev.cognitivity.chronal.ui.metronome.components.TempoChanger
 
 @Composable
 fun CircularDisplay(viewModel: MetronomeViewModel, tracks: List<MetronomeTrack>, modifier: Modifier = Modifier) {
-    val displayTracks = tracks.filter { it.enabled }
+    val sequenceTrack = viewModel.sequenceDisplayTrack(tracks)
+    val displayTracks = sequenceTrack?.let { listOf(it) } ?: tracks.filter { it.enabled }
     if (displayTracks.isEmpty()) return
 
     Box(

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/pages/ConductorDisplay.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/pages/ConductorDisplay.kt
@@ -66,6 +66,7 @@ import dev.cognitivity.chronal.round
 import dev.cognitivity.chronal.settings.Settings
 import dev.cognitivity.chronal.toPx
 import dev.cognitivity.chronal.ui.metronome.MetronomeViewModel
+import dev.cognitivity.chronal.ui.metronome.sequenceDisplayTrack
 import dev.cognitivity.chronal.ui.metronome.components.TempoChanger
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -75,7 +76,7 @@ import kotlin.math.abs
 //   - separate versions for different time signatures (5/4, 6/8...)
 @Composable
 fun ConductorDisplay(viewModel: MetronomeViewModel, metronome: Metronome, tracks: List<MetronomeTrack>, modifier: Modifier = Modifier) {
-    val displayTrack = tracks.firstOrNull { it.enabled } ?: return
+    val displayTrack = viewModel.sequenceDisplayTrack(tracks) ?: tracks.firstOrNull { it.enabled } ?: return
     val palette = displayTrack.color.getPalette()
     val flipped by viewModel.flipConductor.collectAsState()
 

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/pages/GridDisplay.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/pages/GridDisplay.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import dev.cognitivity.chronal.ChronalApp
 import dev.cognitivity.chronal.metronome.MetronomeTrack
 import dev.cognitivity.chronal.ui.metronome.MetronomeViewModel
+import dev.cognitivity.chronal.ui.metronome.sequenceDisplayTrack
 import dev.cognitivity.chronal.ui.metronome.components.GridDisplayItem
 import dev.cognitivity.chronal.ui.metronome.components.TempoChanger
 import kotlin.math.ceil
@@ -44,7 +45,9 @@ import kotlin.math.sqrt
 
 @Composable
 fun GridDisplay(viewModel: MetronomeViewModel, tracks: List<MetronomeTrack>, modifier: Modifier = Modifier) {
-    val displayTracks = tracks.withIndex().filter { it.value.enabled }
+    val sequenceTrack = viewModel.sequenceDisplayTrack(tracks)
+    val displayTracks = sequenceTrack?.let { listOf(IndexedValue(tracks.indexOf(it), it)) }
+        ?: tracks.withIndex().filter { it.value.enabled }
     if (displayTracks.isEmpty()) return
 
     Column(
@@ -81,7 +84,7 @@ fun GridDisplay(viewModel: MetronomeViewModel, tracks: List<MetronomeTrack>, mod
                             val trackIndex = row * columns + column
                             if (trackIndex >= displayTracks.size) continue
                             val trackEntry = displayTracks[trackIndex]
-                            key(trackEntry.index) {
+                            key(trackEntry.index, trackEntry.value) {
                                 GridDisplayItem(
                                     index = trackEntry.index,
                                     track = trackEntry.value,

--- a/app/src/main/java/dev/cognitivity/chronal/ui/metronome/pages/PieDisplay.kt
+++ b/app/src/main/java/dev/cognitivity/chronal/ui/metronome/pages/PieDisplay.kt
@@ -31,12 +31,14 @@ import dev.cognitivity.chronal.ChronalApp
 import dev.cognitivity.chronal.metronome.MetronomeTrack
 import dev.cognitivity.chronal.toPx
 import dev.cognitivity.chronal.ui.metronome.MetronomeViewModel
+import dev.cognitivity.chronal.ui.metronome.sequenceDisplayTrack
 import dev.cognitivity.chronal.ui.metronome.components.PieRing
 import dev.cognitivity.chronal.ui.metronome.components.TempoChanger
 
 @Composable
 fun PieDisplay(viewModel: MetronomeViewModel, tracks: List<MetronomeTrack>, modifier: Modifier = Modifier) {
-    val displayTracks = tracks.filter { it.enabled }
+    val sequenceTrack = viewModel.sequenceDisplayTrack(tracks)
+    val displayTracks = sequenceTrack?.let { listOf(it) } ?: tracks.filter { it.enabled }
     if (displayTracks.isEmpty()) return
 
     Box(

--- a/app/src/main/res/drawable/outline_playlist_play_24.xml
+++ b/app/src/main/res/drawable/outline_playlist_play_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M120,320L120,240L600,240L600,320L120,320ZM120,480L120,400L600,400L600,480L120,480ZM120,640L120,560L440,560L440,640L120,640ZM640,800L640,480L880,640L640,800Z"/>
+
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,20 @@
     <string name="metronome_display_pie">Pie</string>
     <string name="metronome_switch_display_mode">Switch display modes</string>
 
+    <string name="metronome_sequence">Sequence</string>
+    <string name="metronome_sequence_open">Sequence mode</string>
+    <string name="metronome_sequence_add_step">Add step</string>
+    <string name="metronome_sequence_remove_step">Remove step</string>
+    <string name="metronome_sequence_select_track">Select track</string>
+    <string name="metronome_sequence_empty">No steps yet. Add a step to build a sequence.</string>
+    <string name="metronome_sequence_progress">%1$s — bar %2$d/%3$d</string>
+    <string name="metronome_sequence_decrease_bars">Fewer bars</string>
+    <string name="metronome_sequence_increase_bars">More bars</string>
+    <plurals name="metronome_sequence_bars">
+        <item quantity="one">%d bar</item>
+        <item quantity="other">%d bars</item>
+    </plurals>
+
     <string name="metronome_conductor_not_supported">Current time signature is not yet supported.</string>
     <string name="metronome_conductor_flip">Flip horizontally</string>
     <string name="metronome_increase_tempo">Increase tempo</string>


### PR DESCRIPTION
Sorry, I wanted to rebase and accidentally closed the previous PR.

This is a feature requested by my saxophone teacher. He wanted to be able to create complex sequential rhythms on a metronome. So I made Claude make it. To me the code and the result looks good, but I'm not an app or kotlin developer, so I can't fully judge the quality.

Here's Claude's summary:

Adds a new mode where playback follows a user-defined ordered list of steps (track + number of bars) instead of playing all enabled tracks simultaneously. The sequence loops until stopped, switches tracks sample-accurately at bar boundaries, and persists in MetronomeConfig.

- MetronomeSequencer + Metronome.mixSequence(): plays only the active step's track, counts bars, hands off at the exact switch sample
- Sequence editor bottom sheet (enable switch, reorderable steps, track picker, bars stepper) opened from a new top-right icon
- Visualizers show only the active track and follow its time signature; progress label shows "Track — bar x/y" (also in fullscreen)
- Track enable switches are disabled while sequence mode is on
- Settings.removeTrack re-indexes sequence steps on track deletion and fixes a pre-existing bug where the engine track list was rebuilt from the stale config.

And here's a video:


https://github.com/user-attachments/assets/66e9ae28-83a9-40e0-bc6a-7b99a16f43f7

